### PR TITLE
Add gymcam

### DIFF
--- a/lib/domains/nl/gymcam.txt
+++ b/lib/domains/nl/gymcam.txt
@@ -1,0 +1,1 @@
+Gymnasium Camphusianum


### PR DESCRIPTION
- the university official website URL, if it is different from the domain you are submitting
https://camphusianum.nl/
- a URL of a page on the official website where a long-term (>1 year) IT related course is offered by the university
https://camphusianum.nl/Onderwijs/Eerste_Fase_/_Onderbouw/Studium_Generale_Leerjaar_2
- a URL of a page or some other proof (.pdf or a screenshot are OK) showing that the university recognizes the domain which you are submitting as an official email domain for the enrolled students.
![Screenshot from 2020-04-13 21-37-22](https://user-images.githubusercontent.com/59371454/79153953-08596500-7dcf-11ea-9128-60ce9f5bb580.png)
